### PR TITLE
Partial reads from Stream

### DIFF
--- a/Src/Core/Core.csproj
+++ b/Src/Core/Core.csproj
@@ -81,6 +81,7 @@
     <Compile Include="EbmlReader.cs" />
     <Compile Include="MasterBlockWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StreamExtensions.cs" />
     <Compile Include="Tests\EbmlWriterTests.cs" />
     <Compile Include="Tests\VIntTests.cs" />
     <Compile Include="Union.cs" />

--- a/Src/Core/EbmlReader.cs
+++ b/Src/Core/EbmlReader.cs
@@ -311,7 +311,7 @@ namespace NEbml.Core
 			{
 				return -1;
 			}
-			int r = _source.Read(buffer, offset, (int) Math.Min(_element.Remaining, length));
+			int r = _source.ReadFully(buffer, offset, (int) Math.Min(_element.Remaining, length));
 			if (r < 0)
 			{
 				throw new EndOfStreamException();
@@ -367,7 +367,7 @@ namespace NEbml.Core
 			}
 			while (length > 0)
 			{
-				int r = _source.Read(buffer, offset, length);
+				int r = _source.ReadFully(buffer, offset, length);
 				if (r < 0)
 				{
 					throw new EndOfStreamException();
@@ -401,7 +401,7 @@ namespace NEbml.Core
 			while (length > 0L)
 			{
 				var buffer = GetSharedBuffer(2048);
-				var r = _source.Read(buffer, 0, (int) Math.Min(length, buffer.Length));
+				var r = _source.ReadFully(buffer, 0, (int) Math.Min(length, buffer.Length));
 				if (r < 0)
 				{
 					throw new EndOfStreamException();

--- a/Src/Core/StreamExtensions.cs
+++ b/Src/Core/StreamExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace NEbml.Core
+{
+	public static class StreamExtensions
+	{
+		public static int ReadFully(this Stream stream, byte[] buffer, int offset, int count)
+		{
+			int bytesRead = 0;
+			int totalBytesRead = 0;
+
+			do
+			{
+				bytesRead = stream.Read(buffer, offset + totalBytesRead, count - totalBytesRead);
+				totalBytesRead += bytesRead;
+			} while (bytesRead > 0 && totalBytesRead < count);
+
+			return totalBytesRead;
+		}
+	}
+}

--- a/Src/Core/VInt.cs
+++ b/Src/Core/VInt.cs
@@ -196,7 +196,7 @@ namespace NEbml.Core
 		{
 			buffer = buffer ?? new byte[maxLength];
 
-			if (source.Read(buffer, 0, 1) == 0)
+			if (source.ReadFully(buffer, 0, 1) == 0)
 			{
 				throw new EndOfStreamException();
 			}
@@ -212,7 +212,7 @@ namespace NEbml.Core
 			if (extraBytes + 1 > maxLength)
 				throw new EbmlDataFormatException(string.Format("Expected VInt with a max length of {0}. Got {1}", maxLength, extraBytes + 1));
 
-			if (source.Read(buffer, 1, extraBytes) != extraBytes)
+			if (source.ReadFully(buffer, 1, extraBytes) != extraBytes)
 			{
 				throw new EndOfStreamException();
 			}

--- a/Src/build.cmd
+++ b/Src/build.cmd
@@ -1,5 +1,10 @@
 @echo off
 
+if exist "%VS120COMNTOOLS%vsvars32.bat" (
+  @call "%VS120COMNTOOLS%vsvars32.bat"
+  goto build
+)
+
 if exist "%VS110COMNTOOLS%vsvars32.bat" (
   @call "%VS110COMNTOOLS%vsvars32.bat"
   goto build
@@ -10,7 +15,7 @@ if exist "%VS100COMNTOOLS%vsvars32.bat" (
   goto build
 )
 
-echo Requires VS2012 or VS2010 to be installed
+echo Requires VS2013 or VS2012 or VS2010 to be installed
 goto exit
 
 :build

--- a/Src/pack.cmd
+++ b/Src/pack.cmd
@@ -1,6 +1,7 @@
 rem msbuild NEbml.sln /p:Configuration=Release /t:Clean,Build
 
 del /Q /F nupackage\lib\*.*
+mkdir nupackage\lib
 copy Core\bin\Release\NEbml.Core.* nupackage\lib
 
 cd nupackage


### PR DESCRIPTION
While using EbmlReader with special types of Streams (e.g. the ones that read data from the network, like the Stream returned by `Microsoft.WindowsAzure.Storage.Blob.CloudBlockBlob.OpenRead()`) and when a single call to Read() crosses the boundary of the Stream's internal buffer size it returns partial data, as explicitly noted in the method's documentation. I replaced all the single Read() calls with calls to a Stream extension method that basically does the same as your ReadFully method. This effectively solved the problem for me.

Also, the build script had a bug: if the nupackage\lib directory does not exist (it doesn't in your repository) the command `copy Core\bin\Release\NEbml.Core.* nupackage\lib` creates a lib file inside the nupackage directory containing the last file copied by the command. I added a mkdir to explicitly create the lib directory.