### PR TITLE
add optional argument to ReadNext that allows precise seeking

### DIFF
--- a/Src/Core/EbmlReader.cs
+++ b/Src/Core/EbmlReader.cs
@@ -88,6 +88,10 @@ namespace NEbml.Core
 
 			if (position.HasValue)
 			{
+				if (position < _source.Position)
+				{
+					throw new EbmlDataFormatException("invalid position, seeking backwards is not supported");
+				}
 				Skip(position.Value - (_container.Size - _container.Remaining));
 			}
 

--- a/Src/Core/EbmlReader.cs
+++ b/Src/Core/EbmlReader.cs
@@ -69,12 +69,42 @@ namespace NEbml.Core
 		#region Public API
 
 		/// <summary>
-		/// Reads the next child element of the current container and positions the stream at the beginning of the element data.
+		/// Reads the next child element of the current container at the specified position and positions the stream at the beginning of the element data.
 		/// </summary>
 		/// <param name="position">The exact position in the current container to read the next element from.</param>
 		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
 		/// <exception cref="EbmlDataFormatException">if the value of the element identifier or element data size read from the stream is reserved</exception>
-		public bool ReadNext(long? position = null)
+		public bool ReadAt(long position)
+		{
+			_container.Remaining -= _element.Size;
+			_element = _container;
+			
+			if (_element.Remaining < 1)
+			{
+				_element = Element.Empty;
+				return false;
+			}
+
+			// compute the desired position relative to the current position in the container
+			var relativePosition = position - (_container.Size - _container.Remaining);
+			
+			if (relativePosition < 0)
+			{
+				throw new EbmlDataFormatException("invalid position, seeking backwards is not supported");
+			}
+			
+			Skip(relativePosition);
+
+			ReadElement();
+			return true;
+		}
+
+		/// <summary>
+		/// Reads the next child element of the current container and positions the stream at the beginning of the element data.
+		/// </summary>
+		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
+		/// <exception cref="EbmlDataFormatException">if the value of the element identifier or element data size read from the stream is reserved</exception>
+		public bool ReadNext()
 		{
 			Skip(_element.Remaining);
 			_container.Remaining -= _element.Size;
@@ -85,31 +115,8 @@ namespace NEbml.Core
 				_element = Element.Empty;
 				return false;
 			}
-
-			if (position.HasValue)
-			{
-				if (position < _source.Position)
-				{
-					throw new EbmlDataFormatException("invalid position, seeking backwards is not supported");
-				}
-				Skip(position.Value - (_container.Size - _container.Remaining));
-			}
-
-			ElementPosition = _source.Position;
 			
-			var identifier = ReadVarInt(4);
-
-			if (identifier.IsReserved)
-			{
-				throw new EbmlDataFormatException("invalid element identifier value");
-			}
-
-			var size = ReadVarInt(8).Value;
-			if (size > (ulong)_container.Remaining)
-			{
-				throw new EbmlDataFormatException("invalid element size value");
-			}
-			_element = new Element(identifier, (long) size, ElementType.None);
+			ReadElement();
 			return true;
 		}
 
@@ -413,6 +420,26 @@ namespace NEbml.Core
 				length -= r;
 				_element.Remaining -= r;
 			}
+		}
+
+		private void ReadElement()
+		{
+			ElementPosition = _source.Position;
+
+			var identifier = ReadVarInt(4);
+
+			if (identifier.IsReserved)
+			{
+				throw new EbmlDataFormatException("invalid element identifier value");
+			}
+
+			var size = ReadVarInt(8).Value;
+			if (size > (ulong)_container.Remaining)
+			{
+				throw new EbmlDataFormatException("invalid element size value");
+			}
+			
+			_element = new Element(identifier, (long) size, ElementType.None);
 		}
 
 		/// <summary>

--- a/Src/Core/EbmlReader.cs
+++ b/Src/Core/EbmlReader.cs
@@ -71,9 +71,10 @@ namespace NEbml.Core
 		/// <summary>
 		/// Reads the next child element of the current container and positions the stream at the beginning of the element data.
 		/// </summary>
+		/// <param name="position">The exact position in the current container to read the next element from.</param>
 		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
 		/// <exception cref="EbmlDataFormatException">if the value of the element identifier or element data size read from the stream is reserved</exception>
-		public bool ReadNext()
+		public bool ReadNext(long? position = null)
 		{
 			Skip(_element.Remaining);
 			_container.Remaining -= _element.Size;
@@ -85,7 +86,13 @@ namespace NEbml.Core
 				return false;
 			}
 
+			if (position.HasValue)
+			{
+				Skip(position.Value - (_container.Size - _container.Remaining));
+			}
+
 			ElementPosition = _source.Position;
+			
 			var identifier = ReadVarInt(4);
 
 			if (identifier.IsReserved)
@@ -167,10 +174,8 @@ namespace NEbml.Core
 				throw new InvalidOperationException();
 			}
 			_container.Remaining -= _element.Size;
-			Skip(_container.Remaining);
-			_container.Remaining = 0;
 			_element = _container;
-
+			Skip(_element.Remaining);
 			_container = _containers.Pop();
 		}
 

--- a/Src/Core/EbmlReader.cs
+++ b/Src/Core/EbmlReader.cs
@@ -69,37 +69,6 @@ namespace NEbml.Core
 		#region Public API
 
 		/// <summary>
-		/// Reads the next child element of the current container at the specified position and positions the stream at the beginning of the element data.
-		/// </summary>
-		/// <param name="position">The exact position in the current container to read the next element from.</param>
-		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
-		/// <exception cref="EbmlDataFormatException">if the value of the element identifier or element data size read from the stream is reserved</exception>
-		public bool ReadAt(long position)
-		{
-			_container.Remaining -= _element.Size;
-			_element = _container;
-			
-			if (_element.Remaining < 1)
-			{
-				_element = Element.Empty;
-				return false;
-			}
-
-			// compute the desired position relative to the current position in the container
-			var relativePosition = position - (_container.Size - _container.Remaining);
-			
-			if (relativePosition < 0)
-			{
-				throw new EbmlDataFormatException("invalid position, seeking backwards is not supported");
-			}
-			
-			Skip(relativePosition);
-
-			ReadElement();
-			return true;
-		}
-
-		/// <summary>
 		/// Reads the next child element of the current container and positions the stream at the beginning of the element data.
 		/// </summary>
 		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
@@ -116,6 +85,37 @@ namespace NEbml.Core
 				return false;
 			}
 			
+			ReadElement();
+			return true;
+		}
+
+		/// <summary>
+		/// Reads the next child element of the current container at the specified position and positions the stream at the beginning of the element data.
+		/// </summary>
+		/// <param name="position">The exact position in the current container to read the next element from.</param>
+		/// <returns><code>true</code> if the child element is available; <code>false</code> otherwise</returns>
+		/// <exception cref="EbmlDataFormatException">if the value of the element identifier or element data size read from the stream is reserved</exception>
+		public bool ReadAt(long position)
+		{
+			_container.Remaining -= _element.Size;
+			_element = _container;
+
+			if (_element.Remaining < 1)
+			{
+				_element = Element.Empty;
+				return false;
+			}
+
+			// compute the desired position relative to the current position in the container
+			var relativePosition = position - (_container.Size - _container.Remaining);
+
+			if (relativePosition < 0)
+			{
+				throw new EbmlDataFormatException("invalid position, seeking backwards is not supported");
+			}
+
+			Skip(relativePosition);
+
 			ReadElement();
 			return true;
 		}


### PR DESCRIPTION
bonus: allow LeaveContainer to be called without reading to the end

#### Reason for changes
I am trying to write a fast parser for the Matroska container, which Ebml was originally made for. Your lib seems to be the best way to achieve this without big rewrites.

I have added an optional argument to ReadNext which allows reading the next element at a specific position. In conjunction with [`SeekHead`](https://matroska.org/technical/elements.html#SeekHead) this enables you to seek to a desired segment without seeking through the whole file.

As a bonus I made some changes to LeaveContainer such that it handles leaving a container without reading all elements. I didn't see a reason not to allow it, but maybe you have/had a valid reason?